### PR TITLE
set maxSockets and fix around timeout

### DIFF
--- a/tools/agent.js
+++ b/tools/agent.js
@@ -2,7 +2,7 @@ var async = require('async'),
     fs = require('fs'),
     http = require('http'),
     child = require('child_process');
-
+http.globalAgent.maxSockets = 30;
 var express = require('express'),
     app = express();
 


### PR DESCRIPTION
node.js v0.10.15 で動きました
- maxSocketsで1ホストに対する同時アクセス数を増やす
- setTimeoutがリクエスト完了後も動いてしまうようなので、timeoutedのチェックからリクエストが完了しているかのチェックに変更
